### PR TITLE
Removed properties which are not part of AggregateCollection schema

### DIFF
--- a/lib-dmtf/model/storage.go
+++ b/lib-dmtf/model/storage.go
@@ -20,7 +20,7 @@ type Storage struct {
 	ODataContext       string                `json:"@odata.context,omitempty"`
 	ODataEtag          string                `json:"@odata.etag,omitempty"`
 	ODataType          string                `json:"@odata.type,omitempty"`
-	Description        string                `json:"description,omitempty"`
+	Description        string                `json:"Description,omitempty"`
 	ID                 string                `json:"Id,omitempty"`
 	Name               string                `json:"Name,omitempty"`
 	Oem                *Oem                  `json:"Oem,omitempty"`

--- a/svc-aggregation/system/aggregate.go
+++ b/svc-aggregation/system/aggregate.go
@@ -155,8 +155,8 @@ func (e *ExternalInterface) GetAllAggregates(req *aggregatorproto.AggregatorRequ
 		OdataType:    "#AggregateCollection.AggregateCollection",
 		OdataID:      "/redfish/v1/AggregationService/Aggregates",
 		OdataContext: "/redfish/v1/$metadata#AggregateCollection.AggregateCollection",
-		ID:           "Aggregate",
 		Name:         "Aggregate",
+		Description:  "Aggregate collection view",
 	}
 	resp.Header = map[string]string{
 		"Cache-Control":     "no-cache",
@@ -165,7 +165,7 @@ func (e *ExternalInterface) GetAllAggregates(req *aggregatorproto.AggregatorRequ
 		"Transfer-Encoding": "chunked",
 		"OData-Version":     "4.0",
 	}
-	commonResponse.CreateGenericResponse(response.Success)
+
 	resp.Body = agresponse.List{
 		Response:     commonResponse,
 		MembersCount: len(members),


### PR DESCRIPTION
Removed Id, Message, MessageId and Severity properties from API - /redfish/v1/AggregationService/Aggregates
and Added Description property as per spec of AggregateCollection schema
Changed the property description to Description in Storage API
